### PR TITLE
refactor: migrate to @sanity/ui

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "plugin-template-tool",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Plugin template for a basic, empty tool",
   "repository": {
     "type": "git",
@@ -20,6 +20,6 @@
   "sanityTemplate": {
     "suggestedName": "my-custom-tool",
     "requiresConfig": false,
-    "minimumBaseVersion": "0.119.0"
+    "minimumBaseVersion": "2.13.0"
   }
 }

--- a/template/MyTool.css
+++ b/template/MyTool.css
@@ -1,3 +1,0 @@
-.container {
-  padding: 10px;
-}

--- a/template/MyTool.js
+++ b/template/MyTool.js
@@ -1,19 +1,15 @@
 import React from 'react'
-
-// Sanity uses CSS modules for styling. We import a stylesheet and get an
-// object where the keys matches the class names defined in the CSS file and
-// the values are a unique, generated class name. This allows you to write CSS
-// with only your components in mind without any conflicting class names.
-// See https://github.com/css-modules/css-modules for more info.
-import styles from './MyTool.css'
+import {Box, Text, Stack} from '@sanity/ui'
 
 class MyTool extends React.Component {
   render() {
     return (
-      <div className={styles.container}>
-        <p>This is a blank slate for you to build on.</p>
-        <p>Tools are just React components!</p>
-      </div>
+      <Box padding={4} paddingY={5}>
+        <Stack space={4}>
+          <Text as="p">This is a blank slate for you to build on.</Text>
+          <Text as="p">Tools are just React components!</Text>
+        </Stack>
+      </Box>
     )
   }
 }


### PR DESCRIPTION
This migrates the template to `@sanity/ui`.

|Before|After|
|---|---|
|![Before](https://user-images.githubusercontent.com/10508/136060789-28fe5b8a-3bf3-4d31-ba07-03929f981c9a.png)|![After](https://user-images.githubusercontent.com/10508/136060949-d1e147c8-8ebb-413a-8fe6-f2d93b9ba92a.png)|
